### PR TITLE
Fix "pod" Command Listing

### DIFF
--- a/cmd/pods.go
+++ b/cmd/pods.go
@@ -73,9 +73,12 @@ where the pods are scheduled.`,
 
 			if string(node) != "" {
 
-				kv := strings.Split(string(node), "   ")
+				kv := strings.Fields(string(node))
 
 				k, v := kv[0], kv[1]
+
+				// Print k,v for debug
+				//fmt.Println(k, v)
 
 				nodeinfo[k] = v
 				nodeazs[v] = struct{}{}
@@ -127,7 +130,7 @@ func buildPods(nodeinfo map[string]string, nodeazs map[string]struct{}, k8sNames
 			podMap[p.name] = p
 
 			// Print pod info for debug
-			//fmt.Printf("Pod: %s\n", podMap[p.name])
+			fmt.Printf("Pod: %s\n", podMap[p.name])
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import "github.com/phenixblue/kubectl-azs/cmd"
 var (
 
 	// VERSION defines the version of the utility.
-	VERSION = "v0.0.3"
+	VERSION = "v0.0.4"
 )
 
 func main() {


### PR DESCRIPTION
There was an issue with listing pods by AZ when a cluster had nodes with varying length names. This was fixed by changing from using the `String.Split` method with fixed length whitespace delimiter to using `String.Fields`.